### PR TITLE
FOLLOWUP: Restore Portfolio Command Center to dashboard top

### DIFF
--- a/src/components/dashboard/DashboardClient.tsx
+++ b/src/components/dashboard/DashboardClient.tsx
@@ -58,6 +58,16 @@ function DashboardContent({ user, userProperties }: DashboardClientProps) {
       </header>
 
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
+        {/* Portfolio Command Center - Top Priority Display */}
+        {userProperties.length > 0 && (
+          <div className="mb-12">
+            <PortfolioSummaryCard
+              propertyCount={userProperties.length}
+            />
+          </div>
+        )}
+
+        {/* Properties Section */}
         <div className="mb-8">
           <div className="flex justify-between items-center mb-6">
             <div>
@@ -111,7 +121,7 @@ function DashboardContent({ user, userProperties }: DashboardClientProps) {
 
         {/* Summary Stats */}
         {userProperties.length > 0 && (
-          <div className="mt-12 grid gap-6 md:grid-cols-3">
+          <div className="mt-12 grid gap-6 md:grid-cols-2">
             <Card className="border border-violet-200 bg-white">
               <CardContent className="p-6">
                 <div className="flex items-center justify-between">
@@ -139,10 +149,6 @@ function DashboardContent({ user, userProperties }: DashboardClientProps) {
                 </div>
               </CardContent>
             </Card>
-
-            <PortfolioSummaryCard
-              propertyCount={userProperties.length}
-            />
           </div>
         )}
       </main>


### PR DESCRIPTION
## Dashboard Layout Fix

**Issue**: Portfolio Command Center was accidentally moved from top to bottom during GH-31 implementation.

**Root Cause**: 
During the Dashboard year sync + Smart date defaults implementation (commit eaf554e), the layout was accidentally flipped:
- Portfolio Command Center was removed from the top
- PortfolioSummaryCard was added to the bottom summary section

**Original Intent** (from commit 60a1104):


**Accidental Layout** (from commit eaf554e):


**This Fix**:
- ✅ Move PortfolioSummaryCard back to top priority position
- ✅ Restore Portfolio Command Center above property cards
- ✅ Fix summary stats grid layout (md:grid-cols-2)

**User Experience**:
- Users now see portfolio overview FIRST (command center)
- Individual property cards appear BELOW the overview
- Matches original dashboard design intent

Fixes: Accidental layout flip from GH-31 implementation
Related: Previous hotfix for serialization error