### PR TITLE
feat: Use US Letter format for PDF exports

### DIFF
--- a/src/app/api/reports/pdf/route.ts
+++ b/src/app/api/reports/pdf/route.ts
@@ -77,7 +77,7 @@ export async function GET(request: NextRequest) {
       await page.setContent(htmlContent, { waitUntil: 'networkidle0' });
 
       const pdfBuffer = await page.pdf({
-        format: 'A4',
+        format: 'Letter',
         printBackground: true,
         margin: {
           top: '1in',


### PR DESCRIPTION
## US Tax Form PDF Format Fix

**Issue**: PDF exports currently use A4 format, which is not standard for US tax forms.

**Solution**: Change to US Letter format for better compatibility with US tax workflows.

**Changes**:
- ✅ Update PDF format from 'A4' to 'Letter' in reports API route
- ✅ Maintain existing margin settings (1in top/bottom, 0.75in sides)
- ✅ No other formatting changes needed

**Impact**:
- **US Users**: Schedule E forms now print correctly on standard US Letter paper
- **Tax Workflow**: Better compatibility with US tax preparation process
- **No Breaking Changes**: Same API, just better paper format

**Testing**:
- PDF generation works with Letter format
- Tax forms fit properly on US standard paper size
- Maintains professional tax document appearance

This addresses the staging branch feature for proper US tax form formatting.

Fixes: US Letter format for tax document printing