### PR TITLE
Fix property switcher boundaries and favicon configuration

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,16 +33,8 @@ export const metadata: Metadata = {
     index: true,
     follow: true,
   },
-  icons: {
-    icon: [
-      { url: '/icon.svg', type: 'image/svg+xml' },
-      { url: '/favicon.ico', sizes: '32x32', type: 'image/x-icon' },
-    ],
-    shortcut: '/favicon.ico',
-    apple: [
-      { url: '/apple-icon.svg', sizes: '180x180', type: 'image/svg+xml' },
-    ],
-  },
+  // Icons are handled automatically by Next.js app directory
+  // icon.tsx, apple-icon.svg, favicon.ico in /src/app/
   manifest: '/site.webmanifest',
   metadataBase: new URL('https://propowl.ai'),
   openGraph: {

--- a/src/components/property/PropertyDetailClient.tsx
+++ b/src/components/property/PropertyDetailClient.tsx
@@ -111,25 +111,26 @@ export default function PropertyDetailClient({ property, user }: PropertyDetailC
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-orange-50 to-blue-50">
       {/* Header */}
-      <header className="bg-white shadow-sm border-b border-gray-200">
+      <header className="bg-white shadow-sm border-b border-gray-200 relative overflow-visible">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-          <div className="flex justify-between items-center">
-            <div className="flex items-center gap-6">
-              <Link href="/dashboard">
+          <div className="flex justify-between items-center min-h-[60px]">
+            <div className="flex items-center gap-4 lg:gap-6 min-w-0 flex-1">
+              <Link href="/dashboard" className="flex-shrink-0">
                 <Button variant="ghost" size="sm" className="flex items-center gap-2 text-gray-600 hover:text-orange-500">
                   <ArrowLeft className="h-4 w-4" />
-                  Back to Properties
+                  <span className="hidden sm:inline">Back to Properties</span>
+                  <span className="sm:hidden">Back</span>
                 </Button>
               </Link>
-              <div className="flex items-center gap-3">
-                <span className="text-4xl">🦉</span>
+              <div className="flex items-center gap-3 flex-shrink-0">
+                <span className="text-3xl lg:text-4xl">🦉</span>
                 <div>
-                  <h1 className="text-2xl font-bold text-orange-500">PropOwl</h1>
-                  <p className="text-sm text-gray-600">Property Tax Management</p>
+                  <h1 className="text-xl lg:text-2xl font-bold text-orange-500">PropOwl</h1>
+                  <p className="text-xs lg:text-sm text-gray-600">Property Tax Management</p>
                 </div>
               </div>
               {/* Property Switcher */}
-              <div className="hidden sm:block">
+              <div className="hidden lg:block flex-shrink-0 relative z-20">
                 <PropertySwitcher
                   currentPropertyId={property.id}
                   currentProperty={{
@@ -155,8 +156,8 @@ export default function PropertyDetailClient({ property, user }: PropertyDetailC
       </header>
 
       {/* Mobile Property Switcher */}
-      <div className="sm:hidden bg-white border-b border-gray-200 shadow-sm">
-        <div className="max-w-7xl mx-auto px-4 py-3">
+      <div className="sm:hidden bg-white border-b border-gray-200 shadow-sm relative overflow-visible">
+        <div className="max-w-7xl mx-auto px-4 py-3 relative z-20">
           <PropertySwitcher
             currentPropertyId={property.id}
             currentProperty={{

--- a/src/components/property/PropertySwitcher.tsx
+++ b/src/components/property/PropertySwitcher.tsx
@@ -79,13 +79,13 @@ export default function PropertySwitcher({ currentPropertyId, currentProperty }:
   // If only one property, don't show the switcher
   if (properties.length <= 1) {
     return (
-      <div className="flex items-center gap-3 px-4 py-2 bg-orange-50 border border-orange-200 rounded-lg">
-        <Building className="h-5 w-5 text-orange-600" />
-        <div className="min-w-0">
+      <div className="flex items-center gap-3 px-4 py-2 bg-orange-50 border border-orange-200 rounded-lg max-w-full">
+        <Building className="h-5 w-5 text-orange-600 flex-shrink-0" />
+        <div className="min-w-0 flex-1">
           <div className="text-sm font-medium text-gray-900 truncate">
             {formatPropertyDisplay(currentProperty)}
           </div>
-          <div className="text-xs text-gray-500">
+          <div className="text-xs text-gray-500 truncate">
             {formatPropertySubtext(currentProperty)}
           </div>
         </div>
@@ -94,14 +94,14 @@ export default function PropertySwitcher({ currentPropertyId, currentProperty }:
   }
 
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex items-center gap-2 relative z-10">
       <Building className="h-5 w-5 text-orange-600 flex-shrink-0" />
       <Select
         value={currentPropertyId}
         onValueChange={handlePropertyChange}
         disabled={isLoading}
       >
-        <SelectTrigger className="min-w-[280px] h-auto py-2 px-3 bg-orange-50 border-orange-200 hover:bg-orange-100 transition-colors">
+        <SelectTrigger className="min-w-[280px] max-w-[320px] h-auto py-2 px-3 bg-orange-50 border-orange-200 hover:bg-orange-100 transition-colors">
           <SelectValue asChild>
             <div className="flex flex-col items-start text-left">
               <div className="text-sm font-medium text-gray-900 truncate max-w-[240px]">
@@ -113,7 +113,17 @@ export default function PropertySwitcher({ currentPropertyId, currentProperty }:
             </div>
           </SelectValue>
         </SelectTrigger>
-        <SelectContent className="max-w-[400px]">
+        <SelectContent
+          className="min-w-[320px] max-w-[450px] z-[9999]"
+          side="bottom"
+          align="start"
+          sideOffset={8}
+          alignOffset={0}
+          avoidCollisions={true}
+          collisionPadding={20}
+          sticky="always"
+          onCloseAutoFocus={(e) => e.preventDefault()}
+        >
           {properties.map((property) => (
             <SelectItem key={property.id} value={property.id} className="py-3">
               <div className="flex items-start gap-3 w-full">


### PR DESCRIPTION
## Summary

Fixes two key UI issues:

1. **Property Switcher Boundaries**: Dropdown was getting cut off at container boundaries
   - Enhanced SelectContent positioning with higher z-index (z-[9999])
   - Added sticky positioning and improved collision avoidance
   - Improved container z-index layering for both desktop and mobile sections
   - Better overflow handling in parent containers

2. **Favicon Configuration**: Favicon wasn't appearing in browser tabs
   - Fixed layout.tsx to use Next.js 13+ app directory approach
   - Removed manual icon references pointing to missing public files
   - Let Next.js handle icons automatically via icon.tsx, apple-icon.svg, favicon.ico
   - Uses consistent owl emoji (🦉) design across all icon formats

## Technical Changes

- **PropertySwitcher.tsx**: Enhanced Select component positioning and z-index
- **PropertyDetailClient.tsx**: Improved container overflow and positioning
- **layout.tsx**: Fixed favicon configuration for Next.js app directory

## Test Plan

- [x] Build passes successfully
- [ ] Property switcher dropdown no longer gets cut off
- [ ] Favicon appears correctly in browser tab
- [ ] Mobile property switcher works properly
- [ ] Desktop property switcher maintains proper positioning

🦉 Generated with [Claude Code](https://claude.com/claude-code)